### PR TITLE
Minimise reviewed comments on desktop

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,37 @@
 //= require_tree .
 
 $(document).on('change', 'input[type=radio]', function (ev) {
-  $(ev.target).parents('.row').addClass('reviewed');
+  if (localStorage['ce5001MinimizeReviewed']) {
+    $(ev.target).parents('.row').addClass('reviewed');
+  }
+});
+
+$(document).on('click', '.toggle-minimize', function (ev) {
+  ev.preventDefault();
+
+  if (localStorage['ce5001MinimizeReviewed']) {
+    localStorage.removeItem('ce5001MinimizeReviewed');
+  }
+  else {
+    localStorage['ce5001MinimizeReviewed'] = 'true';
+  }
+
+  var confirmer = $('<span class="text-success">&#x2713;</span>');
+  confirmer.css({
+    position: 'relative',
+    top: '-0.5em'
+  });
+  $(ev.target).after(confirmer);
+  confirmer.css('transition', 'all 0.5s ease');
+
+  setTimeout(function () {
+    confirmer.css({
+      top: '-1.5em',
+      filter: 'opacity(50%)'
+    });
+    setTimeout(function () {
+      confirmer.remove();
+    }, 500);
+  }, 0);
 });
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,3 +16,8 @@
 //= require activestorage
 //= require turbolinks
 //= require_tree .
+
+$(document).on('change', 'input[type=radio]', function (ev) {
+  $(ev.target).parents('.row').addClass('reviewed');
+});
+

--- a/app/assets/stylesheets/comment.scss
+++ b/app/assets/stylesheets/comment.scss
@@ -33,14 +33,24 @@
   }
 
   .btn-img {
+    transition: all 0.2s ease;
     min-width:4.2em;
     min-height:4em;
 
     img {
+      transition: all 0.2s ease;
       margin-top:0.5em;
       width:2em;
       height:2em;
     }
+  }
+
+  p {
+    transition: all 0.2s ease;
+  }
+
+  .row + hr {
+    transition: all 0.2s ease;
   }
 
   $radius: 0.17rem;
@@ -52,5 +62,36 @@
   .btn-right {
     border-top-right-radius: $radius !important;
     border-bottom-right-radius: $radius !important;
+  }
+
+  @media screen and (min-width: 600px) {
+    .row.reviewed:not(:hover) {
+      transition: all 0.2s ease;
+      filter: opacity(65%);
+
+      .btn-img {
+        transition: all 0.2s ease;
+        min-width: 0.9em;
+        min-height: 0.9em;
+        padding: 0.1rem 0.425rem;
+
+        img {
+          transition: all 0.2s ease;
+          margin-top: 0;
+          width: 0.9em;
+          height: 0.9em;
+        }
+      }
+
+      p {
+        font-size: 0.75em;
+        transition: all 0.2s ease;
+      }
+
+      & + hr {
+        transition: all 0.2s ease;
+        margin-top: 0.2rem;
+      }
+    }
   }
 }

--- a/app/views/comment/evaluate.html.erb
+++ b/app/views/comment/evaluate.html.erb
@@ -3,7 +3,7 @@
 <div class="text-center">
   <h4>
     <% ReviewResult.all.each do |rr| %>
-      <%= rr.emoji_or_fallback %> = <%= rr.name %>
+        <%= rr.emoji_or_fallback %> = <%= rr.name %>
     <% end %>
   </h4>
 </div>
@@ -13,29 +13,29 @@
 <% usermap = {} %>
 <div class="container comment-container">
   <%= form_tag feedback_path, id: 'comment-evaluation' do %>
-  <hr>
-    <div class="container">
-      <% @comments.each do |comment| %>
-        <div class="row">
-          <div class="col-md-3">
-            <div class="btn-group float-md-right" role="group">
-              <% ReviewResult.all.each.with_index do |rr, i| %>
-                <label>
-                  <%= radio_button_tag "comments[#{comment.id}]", rr.id %>
-                  <span class="btn btn-img btn-outline-secondary<%= " btn-left" if i == 0%><%= " btn-right" if i == ReviewResult.count-1 %>"><%= rr.emoji_or_fallback %></span>
-                </label>
-              <% end %>
+      <hr>
+      <div class="container">
+        <% @comments.each do |comment| %>
+            <div class="row">
+              <div class="col-md-3">
+                <div class="btn-group float-md-right" role="group">
+                  <% ReviewResult.all.each.with_index do |rr, i| %>
+                      <label>
+                        <%= radio_button_tag "comments[#{comment.id}]", rr.id %>
+                        <span class="btn btn-img btn-outline-secondary<%= " btn-left" if i == 0%><%= " btn-right" if i == ReviewResult.count-1 %>"><%= rr.emoji_or_fallback %></span>
+                      </label>
+                  <% end %>
+                </div>
+              </div>
+              <div class="col-md-9">
+                <p>
+                  <%= comment.body %> &mdash; <span class="text-primary">user<%= usermap[comment.commenter_id] || usermap[comment.commenter_id] = (('A'..'Z').to_a-usermap.values).shuffle[0.-1][0] %></span>
+                </p>
+              </div>
             </div>
-          </div>
-          <div class="col-md-9">
-            <p>
-              <%= comment.body %> &mdash; <span class="text-primary">user<%= usermap[comment.commenter_id] || usermap[comment.commenter_id] = (('A'..'Z').to_a-usermap.values).shuffle[0.-1][0] %></span>
-            </p>
-          </div>
-        </div>
-        <hr>
-      <% end %>
-    </div>
+            <hr>
+        <% end %>
+      </div>
   <% end %>
 
   <div class='text-center'>
@@ -43,12 +43,17 @@
     <%= link_to "Skip", comment_path, method: :get, class: 'inline mr-4 btn btn-outline-secondary' %>
   </div>
 
-  <br /><br />
+  <br/><br/>
+  <div class="text-center">
+    <small><a href="#" class="toggle-minimize text-muted">Minimize comments once I've reviewed them (click to toggle)</a></small>
+  </div>
+
+  <br/>
   <div class="alert alert-light col-md-8 offset-md-2">
     <%= render 'comment/data_usage', text_center: true %>
   </div>
 
-  <br />
+  <br/>
   <div class="alert alert-light col-md-8 offset-md-2 text-center">
     <small><i><%= link_to "click to see comments on stack overflow (this action is logged)", post_path(id: @post.id), class: 'text-muted' %></i></small>
   </div>


### PR DESCRIPTION
Avoid taking up lots of screen real estate for something I've already reviewed; "minimise" each comment once I've selected a feeling for it. Lets me review stuff much quicker. Only happens on desktop because it'd be annoying on mobile with moving tap targets, etc.